### PR TITLE
Update GAClient and GtagClient to send additional and augmented data back to GA

### DIFF
--- a/analytics/google/experience-accelerator/README.md
+++ b/analytics/google/experience-accelerator/README.md
@@ -16,8 +16,9 @@ These can be added directly to the page and used to configure the integration
 var Evolv=function(e){"use strict";var t=function(){function e(e,t,n,i,r,o){var d=th...
 
 // Configure the integration 
-// with the parameters GAClient(TRACKING_ID, NAMESPACE, USER_ID_METRIC, EXPERIMENT_ID_METRIC (optional))
-const client = new Evolv.GAClient("UA-164633832-3", "", "1", "2");
+// with the parameters GAClient(TRACKING_ID, NAMESPACE, SESSION_ID_DIMENSION, CANDIDATE_ID_DIMENSION, USER_ID_SESSION)
+
+const client = new Evolv.GAClient("UA-164633832-3", "", "1", "2", "3");
 OR
-const client = new Evolv.GtagClient("UA-164633832-3", "1", "2");
+const client = new Evolv.GtagClient("UA-164633832-3", "1", "2", "3");
 ```

--- a/analytics/google/experience-accelerator/src/GtagClient.ts
+++ b/analytics/google/experience-accelerator/src/GtagClient.ts
@@ -3,8 +3,9 @@ import {Client} from "./Client";
 export class GtagClient extends Client {
     constructor(
         public readonly trackingId: string,
+        public readonly sessionIdDimension: string,
+        public readonly candidateIdDimension: string,
         public readonly userIdDimension: string,
-        public readonly experimentIdDimension?: string,
         public readonly maxWaitTime = 5000
     ) {
         super(trackingId, maxWaitTime);
@@ -19,11 +20,29 @@ export class GtagClient extends Client {
             'non_interaction': true
         };
 
-        if (this.experimentIdDimension) {
-            dataMap['dimension' + this.experimentIdDimension] = event.eid;
-        }
-        dataMap['dimension' + this.userIdDimension] = event.uid;
+        var augmentedSid = '';
+        var augmentedCidEid = '';
+        var augmentedUid = '';
 
-        this.emit('event', 'evolv-' + type + (event.cid ? '-' + event.cid : ''), dataMap);
+        if (window.evolv.context.sid) {
+            augmentedSid = 'sid-' + window.evolv.context.sid;
+        }
+
+        if (event.uid) {
+            augmentedUid = "uid-" + event.uid;
+        }
+
+        if (event.cid) {
+            var cidEid = event.cid.split(':');
+            augmentedCidEid = 'cid-' + cidEid[0] + ':eid-' + cidEid[1];
+            dataMap['dimension' + this.candidateIdDimension] = augmentedCidEid;
+        }
+
+        dataMap['dimension' + this.userIdDimension] = augmentedUid;
+        dataMap['dimension' + this.sessionIdDimension] = augmentedSid;
+        dataMap['event_category'] = 'evolvids';
+        dataMap['event_label'] = type + ':' + augmentedUid + ':' + augmentedSid;
+
+        this.emit('event', augmentedCidEid, dataMap);
     }
 }


### PR DESCRIPTION
Updating tests in progress...

Send the following data back to GA for GAClient and GtagClient:

eventAction         (&ea)   cid-<CID>:eid-<EID>  (eg cid-a3ae0cd3965d:eid-92d1919a50)
eventCategory    (&ec)   evolvids
eventLabel           (&el)   <TYPE>:uid-<UID>:sid-<SID> (eg confirmed:uid-75217518_1598053005507:sid-15607447_1598053005507)

dimension<sessionId>           (&cd2)  sid-<SID>     (eg sid-15607447_1598053005507)
dimension<candidateId>       (&cd3)  cid-<CID>:eid-<EID>  (eg cid-a3ae0cd3965d:eid-92d1919a50)
dimension<userId>                  (&cd4)  uid-<UID>  (eg uid-75217518_1598053005507)