### PR TITLE
handle SPA case of multiple confirmations per page load at different …

### DIFF
--- a/analytics/adobe-analytics/experience-accelerator/src/AAClient.ts
+++ b/analytics/adobe-analytics/experience-accelerator/src/AAClient.ts
@@ -35,7 +35,7 @@ export class AAClient extends Client {
 
         var y: any = {};
 
-        y.linkTrackVars = this.userIdDimensionType + this.userIdDimension + ',' + this.sessionIdDimensionType + this.sessionIdDimension + ',' + this.candidateIdDimensionType + this.candidateIdDimension + ',events';
+        y.linkTrackVars = this.userIdDimensionType + this.userIdDimension + ',' + this.sessionIdDimensionType + this.sessionIdDimension + ',' + this.candidateIdDimensionType + this.candidateIdDimension;
 
         y[this.candidateIdDimensionType + this.candidateIdDimension] = augmentedCidEid;
         y[this.userIdDimensionType + this.userIdDimension] = augmentedUid;

--- a/analytics/adobe-analytics/experience-accelerator/src/Client.ts
+++ b/analytics/adobe-analytics/experience-accelerator/src/Client.ts
@@ -1,6 +1,10 @@
 export abstract class Client {
     queue: any[] = [];
     interval: number = 50;
+    activeCandidateEvents: any = {
+        confirmed: {},
+        contaminated: {}
+    };
 
     constructor(
         public readonly maxWaitTime = 5000
@@ -27,8 +31,11 @@ export abstract class Client {
         let contextKey = this.getContextKey(type);
         let candidates = this.getEvolv().context.get(contextKey) || [];
         for (let i = 0; i < candidates.length; i++) {
-            const allocation = this.lookupFromAllocations(candidates[i].cid);
-            this.sendMetrics(type, allocation);
+            if (!this.activeCandidateEvents[type][candidates[i].cid]) {
+                const allocation = this.lookupFromAllocations(candidates[i].cid);
+                this.sendMetrics(type, allocation);
+                this.activeCandidateEvents[type][candidates[i].cid] = true;
+            }
         }
     }
 

--- a/analytics/adobe-analytics/experience-accelerator/src/Client.ts
+++ b/analytics/adobe-analytics/experience-accelerator/src/Client.ts
@@ -31,7 +31,7 @@ export abstract class Client {
         let contextKey = this.getContextKey(type);
         let candidates = this.getEvolv().context.get(contextKey) || [];
         for (let i = 0; i < candidates.length; i++) {
-            if (!this.activeCandidateEvents[type][candidates[i].cid]) {
+            if (this.activeCandidateEvents[type] && !this.activeCandidateEvents[type][candidates?.[i]?.cid]) {
                 const allocation = this.lookupFromAllocations(candidates[i].cid);
                 this.sendMetrics(type, allocation);
                 this.activeCandidateEvents[type][candidates[i].cid] = true;

--- a/analytics/google/experience-accelerator/src/Client.ts
+++ b/analytics/google/experience-accelerator/src/Client.ts
@@ -1,6 +1,11 @@
 export abstract class Client {
     queue: any[] = [];
     interval: number = 50;
+    activeCandidateEvents: any = {
+        confirmed: {},
+        contaminated: {}
+    };
+    contaminations: any = {};
 
     constructor(
         public readonly maxWaitTime = 5000
@@ -27,8 +32,11 @@ export abstract class Client {
         let contextKey = this.getContextKey(type);
         let candidates = this.getEvolv().context.get(contextKey) || [];
         for (let i = 0; i < candidates.length; i++) {
-            const allocation = this.lookupFromAllocations(candidates[i].cid);
-            this.sendMetrics(type, allocation);
+            if (!this.activeCandidateEvents[type][candidates[i].cid]) {
+                const allocation = this.lookupFromAllocations(candidates[i].cid);
+                this.sendMetrics(type, allocation);
+               this.activeCandidateEvents[type][candidates[i].cid] = true;
+            }
         }
     }
 

--- a/analytics/google/experience-accelerator/src/Client.ts
+++ b/analytics/google/experience-accelerator/src/Client.ts
@@ -32,7 +32,7 @@ export abstract class Client {
         let contextKey = this.getContextKey(type);
         let candidates = this.getEvolv().context.get(contextKey) || [];
         for (let i = 0; i < candidates.length; i++) {
-            if (!this.activeCandidateEvents[type][candidates[i].cid]) {
+            if (this.activeCandidateEvents[type] && !this.activeCandidateEvents[type][candidates?.[i]?.cid]) {
                 const allocation = this.lookupFromAllocations(candidates[i].cid);
                 this.sendMetrics(type, allocation);
                this.activeCandidateEvents[type][candidates[i].cid] = true;


### PR DESCRIPTION
…times. Previously we would fire the confirmation for matching experiments multiple times