### PR TITLE
SUP-2212: GA4 support - log warning when using wrong google analytics client

### DIFF
--- a/analytics/google/experience-accelerator/src/Client.ts
+++ b/analytics/google/experience-accelerator/src/Client.ts
@@ -67,6 +67,7 @@ export abstract class Client {
     }
 
     abstract getAnalytics(): any;
+    abstract checkAnalyticsProviders(): void;
 
     // Override for customer analytics processor
     getHandler(): any {
@@ -108,6 +109,7 @@ export abstract class Client {
             if ((Date.now() - begin) > this.maxWaitTime) {
                 clearInterval(intervalId);
                 console.log('Evolv: Analytics integration timed out - Couldn\'t find Analytics');
+                this.checkAnalyticsProviders();
                 return;
             }
 

--- a/analytics/google/experience-accelerator/src/GAClient.ts
+++ b/analytics/google/experience-accelerator/src/GAClient.ts
@@ -14,6 +14,13 @@ export class GAClient extends Client {
         return (window.GoogleAnalyticsObject && window[window.GoogleAnalyticsObject]) || window.ga;
     }
 
+    checkAnalyticsProviders() {
+        // @ts-ignore
+        if (window.google_tag_manager || window.gtag) {
+            console.log('Evolv: Analytics integration detected Google Tag Manager - please use \'Evolv.GtagClient()\'');
+        }
+    }
+
     sendMetrics(type: string, event: any) {
         const namespace = this.namespace;
         const prefix = namespace ? namespace + '.' : '';

--- a/analytics/google/experience-accelerator/src/GtagClient.ts
+++ b/analytics/google/experience-accelerator/src/GtagClient.ts
@@ -11,6 +11,13 @@ export class GtagClient extends Client {
         return window.gtag;
     }
 
+    checkAnalyticsProviders() {
+        // @ts-ignore
+        if ((window.GoogleAnalyticsObject && window[window.GoogleAnalyticsObject]) || window.ga) {
+            console.log('Evolv: Analytics integration detected GA - please use \'Evolv.GAClient()\'');
+        }
+    }
+
     sendMetrics(type: string, event: any) {
         let dataMap: { [key: string]: any; } = {
             'non_interaction': true


### PR DESCRIPTION
If the analytics provider is not found - check if a different provider (ex: GA vs GTM) is present. If one is found, print a message to the console that a different provider was found and which client to use. This will be helpful when trying to use `GAClient` when using GA4 / Google Tag Manager.