### PR TITLE
SUP-2422: update deprecated keys in getContextKey

### DIFF
--- a/analytics/adobe-analytics/experience-accelerator/src/Client.ts
+++ b/analytics/adobe-analytics/experience-accelerator/src/Client.ts
@@ -53,9 +53,9 @@ export abstract class Client {
     private getContextKey(type: string) {
         switch (type) {
             case 'confirmed':
-                return 'confirmations';
+                return 'experiments.confirmations';
             case 'contaminated':
-                return 'contaminations';
+                return 'experiments.contaminations';
             default:
                 return '';
         }

--- a/analytics/google/experience-accelerator/src/Client.ts
+++ b/analytics/google/experience-accelerator/src/Client.ts
@@ -54,9 +54,9 @@ export abstract class Client {
     private getContextKey(type: string) {
         switch (type) {
             case 'confirmed':
-                return 'confirmations';
+                return 'experiments.confirmations';
             case 'contaminated':
-                return 'contaminations';
+                return 'experiments.contaminations';
             default:
                 return '';
         }


### PR DESCRIPTION
Currently getContextKey is returning "contaminations" or "confirmations", which is throwing a deprecated warning in the console, stating to use `experiments.contaminations` and `experiments.confirmations` instead.