### PR TITLE
Segment Integration: allow passing experiment names to config

### DIFF
--- a/packages/segment/README.md
+++ b/packages/segment/README.md
@@ -1,4 +1,4 @@
-## Evolv Segment Integration
+# Evolv Segment Integration
 
 ## Usage
 When using the Segment integration, a map of Segment events to listen for and their respective Evolv events should be passed into the config in `parametersToReadFromSegment`.
@@ -61,6 +61,65 @@ Example:
         },
         "event": "checkout-page-viewed-step-3"
       }]
+    }
+  }
+}
+```
+
+## Confirmation and Contamination events
+
+When Evolv emits a confirmation or contamination event, a Segment `track` event will automatically be emitted in the following formats:
+
+### Confirmation
+```json
+{
+  "event": "Experiment Viewed",
+  "properties": {
+    "experimentId": "<Experiment Group ID>",
+    "experimentName": "Evolv Experiment: <Evolv Group ID>",
+    "variationId": "<Evolv Combination ID>",
+    "variationName": "<Evolv Combination Name>"
+  }
+}
+```
+
+### Contamination
+```json
+{
+  "event": "Experiment Contaminated",
+  "properties": {
+    "experimentId": "<Experiment Group ID>",
+    "experimentName": "Evolv Experiment: <Evolv Group ID>",
+    "variationId": "<Evolv Combination ID>",
+    "variationName": "<Evolv Combination Name>"
+  }
+}
+```
+
+### Other events
+All other events fired from Evolv will emitted as a Segment `track` event in the following format:
+
+```json
+{
+  "event": "Evolv Event: <Evolv Event Name>"
+}
+```
+
+
+## Using readable experiment names
+*Note: this feature is __not recommended__ since it requires manually updating/adding experiment names.*
+
+The `experimentNames` config parameter can be used to pass user-friendly/readable experiment names to be used in the `Experiment Viewed` and `Experiment Contaminated` events. You can pass an object containing a map of `group_id`s to `experimentName`s.
+
+```json
+{
+  "eventListenerAdapter": {
+    "parametersToReadFromSegment": {
+      "Checkout Page Viewed": "checkout-page-viewed"
+    },
+    "experimentNames": {
+      "450daa63-07a3-4859-8153-074fda34bb": "My Experiment Name",
+      "444ada66-70b1-3453-6325-980fdb234a": "My Other Experiment Name"
     }
   }
 }

--- a/packages/segment/package.json
+++ b/packages/segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolv-integrations/segment",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Evolv integration code for Segment",
   "private": false,
   "main": "dist/index.js",

--- a/packages/segment/src/integration.ts
+++ b/packages/segment/src/integration.ts
@@ -3,7 +3,8 @@ import { SegmentEventListenerAdapter } from './event-listener-adapter';
 
 export interface Config {
     eventListenerAdapter: {
-        parametersToReadFromSegment: Record<string, any>
+        parametersToReadFromSegment: Record<string, any>,
+        experimentNames: Record<string, string>
     },
     maxWaitTime?: number;
 }
@@ -11,6 +12,8 @@ export interface Config {
 export function integration(config: Config): void {
     config.eventListenerAdapter = config.eventListenerAdapter || { parametersToReadFromSegment: {} };
     config.eventListenerAdapter.parametersToReadFromSegment = config.eventListenerAdapter.parametersToReadFromSegment || {};
-    const segmentNotifier = new SegmentNotifierAdapter(config.eventListenerAdapter.parametersToReadFromSegment, config.maxWaitTime);
+    config.eventListenerAdapter.experimentNames = config.eventListenerAdapter.experimentNames || {};
+
+    const segmentNotifier = new SegmentNotifierAdapter(config.eventListenerAdapter.parametersToReadFromSegment, config.eventListenerAdapter.experimentNames, config.maxWaitTime);
     const segmentEventListener = new SegmentEventListenerAdapter(config.eventListenerAdapter.parametersToReadFromSegment, config.maxWaitTime);
 }

--- a/packages/segment/src/notifier-adapter.test.ts
+++ b/packages/segment/src/notifier-adapter.test.ts
@@ -1,0 +1,93 @@
+import { SegmentNotifierAdapter } from './notifier-adapter';
+
+describe('Segment Notifier Adapter Test', () => {
+    const experimentNames: Record<string, any> = {
+            'group-id-1': 'My Experiment'
+    };
+
+    let eventMap: Record<string, (args: any, props?: any) => void> = {};
+
+    beforeEach(() => {
+        delete window['evolv'];
+        // @ts-ignore
+        delete window['analytics'];
+        eventMap = {};
+    });
+
+    describe('If experimentNames is not passed', () => {
+        test('Experiment name will fallback', () => {
+            let track = jest.fn();
+
+            // @ts-ignore
+            window['analytics'] = {
+                track
+            };
+
+            window['evolv'] = {
+                client: {
+                    emit: jest.fn(),
+                    on: jest.fn()
+                },
+            };
+
+            const client = new SegmentNotifierAdapter({}, {});
+
+            client.sendMetrics('confirmed', {
+                group_id: 'group-id-1',
+                ordinal: 2,
+                eid: 123,
+                cid: 321
+            });
+
+            expect(track.mock.calls.length).toBe(1);
+            expect(track.mock.calls[0]).toEqual([
+                "Experiment Viewed", {
+                    "experiment_id": 123,
+                    "experiment_name": "Experiment: Evolv Optimization group-id-1",
+                    "nonInteraction": 1,
+                    "variation_id": 321,
+                    "variation_name": "Combination 2",
+                }
+            ]);
+        });
+    });
+
+
+    describe('If experimentNames passed', () => {
+        test('Experiment name will be used', () => {
+            let track = jest.fn();
+
+            // @ts-ignore
+            window['analytics'] = {
+                track
+            };
+
+            window['evolv'] = {
+                client: {
+                    emit: jest.fn(),
+                    on: jest.fn()
+                },
+            };
+
+            const client = new SegmentNotifierAdapter({}, experimentNames);
+
+            client.sendMetrics('confirmed', {
+                group_id: 'group-id-1',
+                ordinal: 2,
+                eid: 123,
+                cid: 321
+            });
+
+            expect(track.mock.calls.length).toBe(1);
+            expect(track.mock.calls[0]).toEqual([
+                "Experiment Viewed", {
+                    "experiment_id": 123,
+                    "experiment_name": "My Experiment",
+                    "nonInteraction": 1,
+                    "variation_id": 321,
+                    "variation_name": "Combination 2",
+                }
+            ]);
+        });
+    });
+});

--- a/packages/segment/src/notifier-adapter.ts
+++ b/packages/segment/src/notifier-adapter.ts
@@ -50,7 +50,7 @@ export class SegmentNotifierAdapter extends AnalyticsNotifierAdapter {
             const eventName = type === 'confirmed' ? 'Experiment Viewed' : 'Experiment Contaminated';
             const experimentName = this.experimentNames[event.group_id] || `Experiment: Evolv Optimization ${event.group_id}`;
             if (event.group_id) {
-                experimentMetaData.experiment_id = event.group_id;
+                experimentMetaData.experiment_id = event.eid;
                 experimentMetaData.experiment_name = experimentName;
                 experimentMetaData.variation_id = event.cid;
                 experimentMetaData.variation_name = `Combination ${event.ordinal}`;

--- a/packages/segment/src/notifier-adapter.ts
+++ b/packages/segment/src/notifier-adapter.ts
@@ -3,6 +3,7 @@ import { AnalyticsNotifierAdapter } from '@evolv-integrations/analytics-adapter'
 export class SegmentNotifierAdapter extends AnalyticsNotifierAdapter {
     constructor(
         public parametersToReadFromSegment: Record<string, any> = {},
+        public experimentNames: Record<string, string> = {},
         public readonly maxWaitTime = 5000
     ) {
         super(maxWaitTime);
@@ -29,25 +30,28 @@ export class SegmentNotifierAdapter extends AnalyticsNotifierAdapter {
                 cid: event.cid
             });
         }
-        const isEvolvEvent = (name: string) => {
-            const eventsMap = Object.values(this.parametersToReadFromSegment);
 
-            if (Array.isArray(this.parametersToReadFromSegment[name])) {
-                this.parametersToReadFromSegment[name].forEach(({ event }: { event: string }) => {
-                    eventsMap.push(event);
-                });
-            } 
+        // Checks if event name is in the list of Segment events
+        const isSegmentEvent = (name: string) => {
+            const eventsMap = Object
+                .values(this.parametersToReadFromSegment)
+                .map(param =>
+                    Array.isArray(param)
+                        ? param.map(({ event }: { event: string }) => event)
+                        : param
+                )
+                .reduce((acc, curr) => acc.concat(curr), []);
 
-            return eventsMap.indexOf(type) === -1;
+            return eventsMap.indexOf(name) !== -1;
         };
 
         if (type === 'confirmed' || type === 'contaminated') {
             const experimentMetaData: any = {};
             const eventName = type === 'confirmed' ? 'Experiment Viewed' : 'Experiment Contaminated';
-
-            if ( event.group_id) {
-                experimentMetaData.experiment_id = event.eid;
-                experimentMetaData.experiment_name = `Experiment: Evolv Optimization ${event.group_id}`;
+            const experimentName = this.experimentNames[event.group_id] || `Experiment: Evolv Optimization ${event.group_id}`;
+            if (event.group_id) {
+                experimentMetaData.experiment_id = event.group_id;
+                experimentMetaData.experiment_name = experimentName;
                 experimentMetaData.variation_id = event.cid;
                 experimentMetaData.variation_name = `Combination ${event.ordinal}`;
             }
@@ -56,7 +60,7 @@ export class SegmentNotifierAdapter extends AnalyticsNotifierAdapter {
                 nonInteraction: 1,
                 ...experimentMetaData
             });
-        } else if (isEvolvEvent(type)) {
+        } else if (!isSegmentEvent(type)) {
             this.emit(`Evolv Event: ${type}`, value);
         }
     }


### PR DESCRIPTION
feat: add experimentNames to Segment config to use readable experiment names