### PR TITLE
Updated getAnalytics to include the dataLayer

### DIFF
--- a/packages/google/ga4-tag-manager/package.json
+++ b/packages/google/ga4-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolv-integrations/ga4-tag-manager",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Evolv integration code for Google Analytics 4 using Google Tag Manager",
   "private": false,
   "main": "dist/index.js",

--- a/packages/google/ga4-tag-manager/src/adapter.ts
+++ b/packages/google/ga4-tag-manager/src/adapter.ts
@@ -8,7 +8,7 @@ export class TagManagerAdapter extends AnalyticsNotifierAdapter {
 	}
 
 	getAnalytics() {
-		return window.google_tag_manager;
+		return window.google_tag_manager && window.dataLayer;
 	}
 
 	getHandler() {


### PR DESCRIPTION
I have a theory that perhaps the dataLayer isn't available sometimes because the GA4 events are triggered by the dataLayer.

At worst, this change will do nothing.